### PR TITLE
Cram md5 checker

### DIFF
--- a/MBMan.pm
+++ b/MBMan.pm
@@ -131,8 +131,6 @@ sub connect
 
     }
 
-    $imap->Showcredentials(1);
-
     $notes->{'00_Status'} = 'Connected';
     return 1;
 

--- a/MBMan.pm
+++ b/MBMan.pm
@@ -169,8 +169,7 @@ sub login
 
     $imap->User($user);
     $imap->Password($pass);
-    $imap->Authmechanism('CRAM-MD5')   if $imap->has_capability('AUTH=CRAM-MD5');
- #   $imap->Authmechanism('DIGEST-MD5') if $imap->has_capability('AUTH=DIGEST-MD5');
+    $imap->Authmechanism('CRAM-MD5');
     $imap->login;
 
     return 0 unless $imap->IsAuthenticated;

--- a/MBMan.pm
+++ b/MBMan.pm
@@ -131,6 +131,8 @@ sub connect
 
     }
 
+    $imap->Showcredentials(1);
+
     $notes->{'00_Status'} = 'Connected';
     return 1;
 
@@ -163,9 +165,12 @@ sub login
     return 0 unless $imap->IsConnected;
     return 0 unless $user;
     return 0 unless $pass;
+    return 0 unless $imap->has_capability('AUTH=CRAM-MD5');
 
     $imap->User($user);
     $imap->Password($pass);
+    $imap->Authmechanism('CRAM-MD5')   if $imap->has_capability('AUTH=CRAM-MD5');
+ #   $imap->Authmechanism('DIGEST-MD5') if $imap->has_capability('AUTH=DIGEST-MD5');
     $imap->login;
 
     return 0 unless $imap->IsAuthenticated;


### PR DESCRIPTION
#15 Dieser Patch bricht die Authentifizierung ab, wenn der IMAP-Server kein AUTH=CRAM-MD5 als Quasi-Standard versteht.